### PR TITLE
clusterTypeData structure not matching the API spec for Addons

### DIFF
--- a/pkg/nirmata/resource_cluster_type_aks.go
+++ b/pkg/nirmata/resource_cluster_type_aks.go
@@ -6,10 +6,11 @@ import (
 	"regexp"
 	"time"
 
+	"strings"
+
 	guuid "github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	client "github.com/nirmata/go-client/pkg/client"
-	"strings"
 )
 
 func resourceAksClusterType() *schema.Resource {
@@ -146,6 +147,16 @@ func resourceClusterTypeCreate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	var otherAddons []map[string]interface{}
+
+	otherAddons = append(otherAddons, map[string]interface{}{
+		"modelIndex":    "AddOnSpec",
+		"name":          "kyverno",
+		"addOnSelector": "kyverno",
+		"catalog":       "default-addon-catalog",
+	},
+	)
+
 	clusterType := map[string]interface{}{
 		"name":        name,
 		"description": "",
@@ -158,11 +169,7 @@ func resourceClusterTypeCreate(d *schema.ResourceData, meta interface{}) error {
 			"addons": map[string]interface{}{
 				"dns":        false,
 				"modelIndex": "AddOns",
-				"addons": map[string]interface{}{
-					"name":          "kyverno",
-					"addOnSelector": "kyverno",
-					"catalog":       "default-addon-catalog",
-				},
+				"other":      otherAddons,
 			},
 			"cloudConfigSpec": map[string]interface{}{
 				"credentials":   cloudCredID.UUID(),

--- a/pkg/nirmata/resource_cluster_type_eks.go
+++ b/pkg/nirmata/resource_cluster_type_eks.go
@@ -2,11 +2,12 @@ package nirmata
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"log"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 
 	guuid "github.com/google/uuid"
 	client "github.com/nirmata/go-client/pkg/client"
@@ -144,6 +145,16 @@ func resourceEksClusterTypeCreate(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
+	var otherAddons []map[string]interface{}
+
+	otherAddons = append(otherAddons, map[string]interface{}{
+		"modelIndex":    "AddOnSpec",
+		"name":          "kyverno",
+		"addOnSelector": "kyverno",
+		"catalog":       "default-addon-catalog",
+	},
+	)
+
 	clusterType := map[string]interface{}{
 		"name":        name,
 		"description": "",
@@ -156,11 +167,7 @@ func resourceEksClusterTypeCreate(d *schema.ResourceData, meta interface{}) erro
 			"addons": map[string]interface{}{
 				"dns":        false,
 				"modelIndex": "AddOns",
-				"addons": map[string]interface{}{
-					"name":          "kyverno",
-					"addOnSelector": "kyverno",
-					"catalog":       "default-addon-catalog",
-				},
+				"other":      otherAddons,
 			},
 			"cloudConfigSpec": map[string]interface{}{
 				"credentials":   cloudCredID.UUID(),

--- a/pkg/nirmata/resource_cluster_type_gke.go
+++ b/pkg/nirmata/resource_cluster_type_gke.go
@@ -312,6 +312,16 @@ func resourceGkeClusterTypeCreate(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 
+	var otherAddons []map[string]interface{}
+
+	otherAddons = append(otherAddons, map[string]interface{}{
+		"modelIndex":    "AddOnSpec",
+		"name":          "kyverno",
+		"addOnSelector": "kyverno",
+		"catalog":       "default-addon-catalog",
+	},
+	)
+
 	clusterTypeData := map[string]interface{}{
 		"name":        name,
 		"description": "",
@@ -325,11 +335,7 @@ func resourceGkeClusterTypeCreate(d *schema.ResourceData, meta interface{}) erro
 			"addons": map[string]interface{}{
 				"dns":        false,
 				"modelIndex": "AddOns",
-				"addons": map[string]interface{}{
-					"name":          "kyverno",
-					"addOnSelector": "kyverno",
-					"catalog":       "default-addon-catalog",
-				},
+				"other":      otherAddons,
 			},
 			"cloudConfigSpec": map[string]interface{}{
 				"credentials":              cloudCredID.UUID(),

--- a/pkg/nirmata/resource_cluster_type_oke.go
+++ b/pkg/nirmata/resource_cluster_type_oke.go
@@ -5,11 +5,12 @@ import (
 	"log"
 	"strings"
 
+	"regexp"
+	"time"
+
 	guuid "github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	client "github.com/nirmata/go-client/pkg/client"
-	"regexp"
-	"time"
 )
 
 func resourceOkeClusterType() *schema.Resource {
@@ -88,6 +89,16 @@ func resourceOkeClusterTypeCreate(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
+	var otherAddons []map[string]interface{}
+
+	otherAddons = append(otherAddons, map[string]interface{}{
+		"modelIndex":    "AddOnSpec",
+		"name":          "kyverno",
+		"addOnSelector": "kyverno",
+		"catalog":       "default-addon-catalog",
+	},
+	)
+
 	clustertype := map[string]interface{}{
 		"name":        name,
 		"description": "",
@@ -100,11 +111,7 @@ func resourceOkeClusterTypeCreate(d *schema.ResourceData, meta interface{}) erro
 			"addons": map[string]interface{}{
 				"dns":        false,
 				"modelIndex": "AddOns",
-				"addons": map[string]interface{}{
-					"name":          "kyverno",
-					"addOnSelector": "kyverno",
-					"catalog":       "default-addon-catalog",
-				},
+				"other":      otherAddons,
 			},
 			"cloudConfigSpec": map[string]interface{}{
 				"credentials":   cloudCredID.UUID(),


### PR DESCRIPTION
`kyverno` is not being added during cluster creation. It seems that the `clusterTypeData` structure is not matching the API spec.