### PR TITLE
Add support for addons on cluster type creation for GKE

### DIFF
--- a/pkg/nirmata/resource_cluster_type_gke.go
+++ b/pkg/nirmata/resource_cluster_type_gke.go
@@ -220,7 +220,11 @@ var addonSchema = map[string]*schema.Schema{
 	},
 	"channel": {
 		Type:     schema.TypeString,
-		Required: true,
+		Optional: true,
+	},
+	"namespace": {
+		Type:     schema.TypeString,
+		Optional: true,
 	},
 	"sequence_number": {
 		Type:     schema.TypeInt,
@@ -363,6 +367,7 @@ func resourceGkeClusterTypeCreate(d *schema.ResourceData, meta interface{}) erro
 				"addOnSelector":  element["addon_selector"],
 				"catalog":        element["catalog"],
 				"channel":        element["channel"],
+				"namespace":      element["namespace"],
 				"sequenceNumber": element["sequence_number"],
 			},
 			)


### PR DESCRIPTION
This PR adds support for Addons on cluster type creation for GKE.

Not covered in this PR and possible next steps:
* support updating existing addons and add/remove addons from cluster type
* support for Addons on cluster type creation for other clusters EKS, AKS, OKE