### PR TITLE
Add support for Vault Auth configuration on cluster type creation for GKE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+terraform-provider-nirmata
 
 # Test binary, built with `go test -c`
 *.test

--- a/examples/vault/gke.tf
+++ b/examples/vault/gke.tf
@@ -43,6 +43,28 @@ resource "nirmata_cluster_type_gke" "gke-cluster-type-1" {
       node = "annotate"
     }
   }
+
+  addons {
+    name            = "vault-agent-injector"
+    addon_selector  = "vault-agent-injector"
+    catalog         = "default-catalog"
+    channel         = "Stable"
+    sequence_number = 15
+  }
+
+  vault_auth {
+    name             = "gke-vault-auth"
+    path             = "nirmata/$(cluster.name)"
+    addon_name       = "vault-agent-injector"
+    credentials_name = "vault_access"
+
+    roles {
+      name                 = "sample-role"
+      service_account_name = "application-sample-sa"
+      namespace            = "application-sample-ns"
+      policies             = "application-sample-policy"
+    }
+  }
 }
 
 // A nirmata_cluster is created using a cluster_type


### PR DESCRIPTION
This PR adds support for Vault Auth configuration on cluster type creation for GKE.

Not covered in this PR and possible next steps:

* support updating Vault Auth configuration
* support for Vault Auth configuration for other clusters EKS, AKS, OKE

This PR also [fixes a bug when no addons are provided](https://github.com/nirmata/terraform-provider-nirmata/pull/43/files#diff-fe78cd43311640de992372face59641a5652201703810166abe7ecd9b8a269daR467-R484).