### PR TITLE
 EKS Registration to Nirmata using Terraform not working

### DIFF
--- a/pkg/nirmata/resource_cluster_registered.go
+++ b/pkg/nirmata/resource_cluster_registered.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"os"
 	"strings"
 	"time"
 
@@ -70,8 +69,6 @@ func resourceClusterRegistered() *schema.Resource {
 }
 
 func resourceClusterRegisteredCreate(d *schema.ResourceData, meta interface{}) error {
-	f, err := os.Create("/tmp/tf.log")
-	defer f.Close()
 	apiClient := meta.(client.Client)
 	name := d.Get("name").(string)
 	labels := d.Get("labels")


### PR DESCRIPTION

The cluster registration was working fine for mac, but not for windows

After capturing the log for the `terraform apply` step, which showed some pointers to the provider code base, which needed further investigation. Eventually pointing the incomplete creation of necessary "temp-**" files by `writeToTempDir()`  mentioned under `pkg\nirmata\resource_cluster_registered.go`

SS attached after building and running the terraform commands

<img width="960" alt="image" src="https://user-images.githubusercontent.com/60812924/225343286-cd4f9c98-b3b1-4e1a-91e5-a56d2357da56.png">
