### PR TITLE
Add support of endpoint parameter for cluster registration

### DIFF
--- a/docs/resources/cluster_aks_registered.md
+++ b/docs/resources/cluster_aks_registered.md
@@ -22,6 +22,7 @@ Register an existing AKS cluster using Kubernetes credentials. The new cluster i
 resource "nirmata_cluster_registered" "aks-registered" {
   name         = "aks-cluster"
   cluster_type = "default-add-ons"
+  endpoint     = "kubernetes cluster API server url"
 }
 
 # Retrieve AKS cluster information
@@ -63,7 +64,4 @@ resource "kubectl_manifest" "test" {
 * `cluster_type` - (Required) Enter the cluster type to apply to the cluster.
 * `labels` - (Optional) This field indicates the labels to be set on cluster.
 * `delete_action` - (Optional) This field indicates whether to delete or remove the cluster on destroy. The default value is `remove`.
-
-
-
-
+* `endpoint` - (Optional) This field indicates the url of the kubernetes cluster API server.

--- a/docs/resources/cluster_eks_imported.md
+++ b/docs/resources/cluster_eks_imported.md
@@ -23,7 +23,7 @@ resource "nirmata_cluster_imported" "eks-import" {
     cluster = "import"
   }
   labels = {foo = "bar"}
-
+  endpoint = "kubernetes cluster API server url"
 }
 
 ```
@@ -38,4 +38,5 @@ resource "nirmata_cluster_imported" "eks-import" {
 * `delete_action` - (Optional) This field indicates whether to delete or remove the cluster on destroy. The default value is `remove`.
 * `system_metadata` - (Optional) This field indicates the key-value pairs that will be provisioned as a ConfigMap called system-metadata-map in the cluster.
 * `labels` - (Optional) This field indicates the labels to be set on the cluster.
+* `endpoint` - (Optional) This field indicates the url of the kubernetes cluster API server.
 

--- a/docs/resources/cluster_eks_registered.md
+++ b/docs/resources/cluster_eks_registered.md
@@ -22,6 +22,7 @@ Register an existing EKS cluster using Kubernetes credentials. The new cluster i
 resource "nirmata_cluster_registered" "eks-registered" {
   name         = "eks-cluster"
   cluster_type = "default-add-ons"
+  endpoint     = "kubernetes cluster API server url"
 }
 
 # Retrieve eks cluster information
@@ -68,7 +69,4 @@ resource "kubectl_manifest" "test" {
 * `cluster_type` - (Required) Enter the cluster type to be applied for the cluster.
 * `labels` - (Optional) This field indicates the labels to be set on the cluster.
 * `delete_action` - (Optional) This field indicates whether to delete or remove the cluster on destroy. The default value is `remove`.
-
-
-
-
+* `endpoint` - (Optional) This field indicates the url of the kubernetes cluster API server.

--- a/docs/resources/cluster_gke_imported.md
+++ b/docs/resources/cluster_gke_imported.md
@@ -24,6 +24,7 @@ resource "nirmata_cluster_imported" "gke-import-1" {
     cluster = "import"
   }
   labels = {foo = "bar"}
+  endpoint = "kubernetes cluster API server url"
 
   vault_auth {
     name             = "vault-auth"
@@ -54,7 +55,7 @@ resource "nirmata_cluster_imported" "gke-import-1" {
 * `delete_action` - (Optional) This field indicates whether to delete or remove the cluster on destroy. The default value is set to `remove`.
 * `system_metadata` - (Optional) This field indicates the key-value pairs that will be provisioned as a ConfigMap called system-metadata-map in the cluster.
 * `labels` - (Optional) This field indicates the labels set on cluster.
-
+* `endpoint` - (Optional) This field indicates the url of the kubernetes cluster API server.
 
 ### vault_auth
 

--- a/docs/resources/cluster_gke_registered.md
+++ b/docs/resources/cluster_gke_registered.md
@@ -23,6 +23,7 @@ Register an existing GKE cluster using Kubernetes credentials. The new cluster i
 resource "nirmata_cluster_registered" "gke-registered" {
   name         = "gke-cluster"
   cluster_type = "default-add-ons"
+  endpoint = "kubernetes cluster API server url"
 }
 
 // fetch the GKE cluster details (requires external configuration)
@@ -63,6 +64,4 @@ resource "kubectl_manifest" "test" {
 * `cluster_type` - (Required) Enter the cluster type to apply.
 * `labels` - (Optional) This field indicates the labels to be set on cluster.
 * `delete_action` - (Optional) This field indicates whether to delete or remove the cluster on destroy. The default value is to `remove`.
-
-
-
+* `endpoint` - (Optional) This field indicates the url of the kubernetes cluster API server.

--- a/docs/resources/cluster_kind_registered.md
+++ b/docs/resources/cluster_kind_registered.md
@@ -22,6 +22,7 @@ Register an existing KIND cluster using Kubernetes credentials. The new cluster 
 resource "nirmata_cluster_registered" "kind-registered" {
   name         = "kind-cluster"
   cluster_type = "default-add-ons"
+  endpoint     = "kubernetes cluster API server url"
 }
 
 variable "host" {
@@ -75,6 +76,7 @@ cluster_ca_certificate = "LS0tLS1CRUdJTiB..."
 * `cluster_type` - (Required) Enter the cluster type to be applied to the cluster.
 * `labels` - (Optional) This field indicates the labels to be set on the cluster.
 * `delete_action` - (Optional) This field indicates whether to delete or remove the cluster on destroy. The default value is `remove`.
+* `endpoint` - (Optional) This field indicates the url of the kubernetes cluster API server.
 
 * `host` -  clusters.cluster.server.
 * `client_certificate` - users.user.client-certificate.

--- a/examples/register/aks/aks.tf
+++ b/examples/register/aks/aks.tf
@@ -12,6 +12,7 @@
 resource "nirmata_cluster_registered" "aks-registered" {
   name         = "aks-cluster"
   cluster_type = "default-add-ons"
+  endpoint     = "https://endpoint"
 }
 
 # Retrieve AKS cluster information
@@ -21,7 +22,7 @@ provider "azurerm" {
 
 data "azurerm_kubernetes_cluster" "cluster" {
   name                = "tf-test"
-  resource_group_name = "nirmata-mustufa-poc"
+  resource_group_name = "tf-test-group"
 }
 
 provider "kubectl" {

--- a/examples/register/aks/version.tf
+++ b/examples/register/aks/version.tf
@@ -1,6 +1,10 @@
 #terraform  nirmata provider 
 terraform {
   required_providers {
+    nirmata = {
+      source = "nirmata/nirmata"
+      version = "1.1.8"
+    }
     azurerm = {
       source  = "hashicorp/azurerm"
       version = "3.0.2"

--- a/pkg/nirmata/resource_cluster.go
+++ b/pkg/nirmata/resource_cluster.go
@@ -80,6 +80,10 @@ func resourceManagedCluster() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
+			"endpoint": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -112,6 +116,7 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 	apiClient := meta.(client.Client)
 	name := d.Get("name").(string)
 	labels := d.Get("labels")
+	endpoint := d.Get("endpoint").(string)
 	nodepools := d.Get("nodepools").([]interface{})
 	typeSelector := d.Get("cluster_type").(string)
 	credentials := d.Get("override_credentials").(string)
@@ -147,6 +152,7 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 		"cloudProvider":  spec["cloud"],
 		"systemMetadata": systemMetadata,
 		"overrideValues": fieldsToOverride,
+		"endpoint": 	  endpoint,
 	}
 
 	data["nodePools"] = nodepool

--- a/pkg/nirmata/resource_cluster_registered.go
+++ b/pkg/nirmata/resource_cluster_registered.go
@@ -50,6 +50,10 @@ var registeredClusterSchema = map[string]*schema.Schema{
 			Type: schema.TypeString,
 		},
 	},
+	"endpoint": {
+		Type:     schema.TypeString,
+		Optional: true,
+	},
 }
 
 func resourceClusterRegistered() *schema.Resource {
@@ -72,6 +76,7 @@ func resourceClusterRegisteredCreate(d *schema.ResourceData, meta interface{}) e
 	apiClient := meta.(client.Client)
 	name := d.Get("name").(string)
 	labels := d.Get("labels")
+	endpoint := d.Get("endpoint").(string)
 	clusterType := d.Get("cluster_type").(string)
 
 	deleteAction := d.Get("delete_action").(string)
@@ -100,6 +105,13 @@ func resourceClusterRegisteredCreate(d *schema.ResourceData, meta interface{}) e
 		"mode":         mode,
 		"labels":       labels,
 		"typeSelector": clusterType,
+	}
+
+	data["config"] = map[string]interface{}{
+		"modelIndex":     "ClusterConfig",
+		"version":        spec["version"],
+		"cloudProvider":  spec["cloud"],
+		"endpoint": 	  endpoint,
 	}
 
 	log.Printf("[DEBUG] - registering cluster %s with %+v", name, data)


### PR DESCRIPTION
Added a new optional parameter `endpoint` to take the endpoint url of the kubernetes api server. This endpoint is passed with the cluster registration request so that when the cluster is registered in Nirmata, the endpoint information is updated with this value.