### PR TITLE
Introduce params for accepting ACLs 

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,20 @@ resource "nirmata_cluster" "eks-eu" {
       max_count                 = 4
    }
    delete_action = "remove"
+   owner_info   = {
+      owner_type = "user"
+      owner_name = "user_email"
+   }
+   access_control_list {
+      entity_type = "user"
+      permission  = "admin"
+      name        = "user_email"
+   }
+   access_control_list {
+      entity_type = "team"
+      permission  = "edit"
+      name        = "team_name"
+   }
 }
 ```
 
@@ -44,7 +58,9 @@ resource "nirmata_cluster" "eks-eu" {
 * `nodepools` - A list of [nodepool](#nodepool) types.
 * `labels` - (Optional) labels to set on cluster.
 * `delete_action` - (Optional) if delete_action set to `remove`, cluster only get removed from the Nirmata not from the original provider and delete_action set to `delete` cluster deleted from nirmata as well as original provider.
-
+* `endpoint` - (Optional) This field indicates the url of the kubernetes cluster API server.
+* `owner_info` - (Optional) The [owner_info](#owner_info) for this cluster, if it has to be overridden.
+* `access_control_list` - (Optional) List of additional [ACLs](#access_control_list) for this cluster.
 ## Nested Blocks
 
 ### nodepool
@@ -53,3 +69,12 @@ resource "nirmata_cluster" "eks-eu" {
 * `enable_auto_scaling` - (Optional) Enable autoscaling for cluster. default valie is disable.
 * `min_count` - (Optional) Set minimun node count value for cluster. `enable_auto_scaling` must set true to set min_count.
 * `max_count` - (Optional) Set max node count value for cluster. `enable_auto_scaling` must set true to set max_count.
+
+### owner_info
+* `owner_type` - (Required) The type of the owner. Valid values are user or team.
+* `owner_name` - (Required) The name of the user/team.
+
+### access_control_list
+* `entity_type` - (Required) The type of entity. Valid values are user or team.
+* `permission` - (Required) The permission. Valid values are admin, edit, view.
+* `name` - (Required) The name of the user/team.

--- a/docs/resources/cluster_aks_registered.md
+++ b/docs/resources/cluster_aks_registered.md
@@ -23,6 +23,20 @@ resource "nirmata_cluster_registered" "aks-registered" {
   name         = "aks-cluster"
   cluster_type = "default-add-ons"
   endpoint     = "kubernetes cluster API server url"
+  owner_info   = {
+    owner_type = "user"
+    owner_name = "user_email"
+  }
+  access_control_list {
+    entity_type = "user"
+    permission  = "admin"
+    name        = "user_email"
+  }
+  access_control_list {
+    entity_type = "team"
+    permission  = "edit"
+    name        = "team_name"
+  }
 }
 
 # Retrieve AKS cluster information
@@ -65,3 +79,14 @@ resource "kubectl_manifest" "test" {
 * `labels` - (Optional) This field indicates the labels to be set on cluster.
 * `delete_action` - (Optional) This field indicates whether to delete or remove the cluster on destroy. The default value is `remove`.
 * `endpoint` - (Optional) This field indicates the url of the kubernetes cluster API server.
+* `owner_info` - (Optional) The [owner_info](#owner_info) for this cluster, if it has to be overridden.
+* `access_control_list` - (Optional) List of additional [ACLs](#access_control_list) for this cluster.
+
+### owner_info
+* `owner_type` - (Required) The type of the owner. Valid values are user or team.
+* `owner_name` - (Required) The name of the user/team.
+
+### access_control_list
+* `entity_type` - (Required) The type of entity. Valid values are user or team.
+* `permission` - (Required) The permission. Valid values are admin, edit, view.
+* `name` - (Required) The name of the user/team.

--- a/docs/resources/cluster_eks_imported.md
+++ b/docs/resources/cluster_eks_imported.md
@@ -39,4 +39,14 @@ resource "nirmata_cluster_imported" "eks-import" {
 * `system_metadata` - (Optional) This field indicates the key-value pairs that will be provisioned as a ConfigMap called system-metadata-map in the cluster.
 * `labels` - (Optional) This field indicates the labels to be set on the cluster.
 * `endpoint` - (Optional) This field indicates the url of the kubernetes cluster API server.
+* `owner_info` - (Optional) The [owner_info](#owner_info) for this cluster, if it has to be overridden.
+* `access_control_list` - (Optional) List of additional [ACLs](#access_control_list) for this cluster.
 
+### owner_info
+* `owner_type` - (Required) The type of the owner. Valid values are user or team.
+* `owner_name` - (Required) The name of the user/team.
+
+### access_control_list
+* `entity_type` - (Required) The type of entity. Valid values are user or team.
+* `permission` - (Required) The permission. Valid values are admin, edit, view.
+* `name` - (Required) The name of the user/team.

--- a/docs/resources/cluster_eks_registered.md
+++ b/docs/resources/cluster_eks_registered.md
@@ -70,3 +70,14 @@ resource "kubectl_manifest" "test" {
 * `labels` - (Optional) This field indicates the labels to be set on the cluster.
 * `delete_action` - (Optional) This field indicates whether to delete or remove the cluster on destroy. The default value is `remove`.
 * `endpoint` - (Optional) This field indicates the url of the kubernetes cluster API server.
+* `owner_info` - (Optional) The [owner_info](#owner_info) for this cluster, if it has to be overridden.
+* `access_control_list` - (Optional) List of additional [ACLs](#access_control_list) for this cluster.
+
+### owner_info
+* `owner_type` - (Required) The type of the owner. Valid values are user or team.
+* `owner_name` - (Required) The name of the user/team.
+
+### access_control_list
+* `entity_type` - (Required) The type of entity. Valid values are user or team.
+* `permission` - (Required) The permission. Valid values are admin, edit, view.
+* `name` - (Required) The name of the user/team.

--- a/docs/resources/cluster_gke_imported.md
+++ b/docs/resources/cluster_gke_imported.md
@@ -56,6 +56,18 @@ resource "nirmata_cluster_imported" "gke-import-1" {
 * `system_metadata` - (Optional) This field indicates the key-value pairs that will be provisioned as a ConfigMap called system-metadata-map in the cluster.
 * `labels` - (Optional) This field indicates the labels set on cluster.
 * `endpoint` - (Optional) This field indicates the url of the kubernetes cluster API server.
+* `owner_info` - (Optional) The [owner_info](#owner_info) for this cluster, if it has to be overridden.
+* `access_control_list` - (Optional) List of additional [ACLs](#access_control_list) for this cluster.
+
+
+### owner_info
+* `owner_type` - (Required) The type of the owner. Valid values are user or team.
+* `owner_name` - (Required) The name of the user/team.
+
+### access_control_list
+* `entity_type` - (Required) The type of entity. Valid values are user or team.
+* `permission` - (Required) The permission. Valid values are admin, edit, view.
+* `name` - (Required) The name of the user/team.
 
 ### vault_auth
 

--- a/docs/resources/cluster_kind_registered.md
+++ b/docs/resources/cluster_kind_registered.md
@@ -77,11 +77,24 @@ cluster_ca_certificate = "LS0tLS1CRUdJTiB..."
 * `labels` - (Optional) This field indicates the labels to be set on the cluster.
 * `delete_action` - (Optional) This field indicates whether to delete or remove the cluster on destroy. The default value is `remove`.
 * `endpoint` - (Optional) This field indicates the url of the kubernetes cluster API server.
+* `owner_info` - (Optional) The [owner_info](#owner_info) for this cluster, if it has to be overridden.
+* `access_control_list` - (Optional) List of additional [ACLs](#access_control_list) for this cluster.
+
 
 * `host` -  clusters.cluster.server.
 * `client_certificate` - users.user.client-certificate.
 * `client_key` - users.user.client-key.
 * `cluster_ca_certificate` - clusters.cluster.certificate-authority-data.
+
+
+### owner_info
+* `owner_type` - (Required) The type of the owner. Valid values are user or team.
+* `owner_name` - (Required) The name of the user/team.
+
+### access_control_list
+* `entity_type` - (Required) The type of entity. Valid values are user or team.
+* `permission` - (Required) The permission. Valid values are admin, edit, view.
+* `name` - (Required) The name of the user/team.
 
 
 

--- a/pkg/nirmata/api_utils.go
+++ b/pkg/nirmata/api_utils.go
@@ -264,3 +264,27 @@ func getPolicyDeployGroupStatus(api client.Client, ID client.ID) (string, error)
 	statusMsg := data["rolloutError"].(string)
 	return statusMsg, nil
 }
+
+func getUsers(api client.Client) ([]map[string]interface{}, error) {
+	opts := &client.GetOptions{}
+	opts.Fields = []string{"id", "name", "modelIndex", "service"}
+	objs, err := api.GetCollection(client.ServiceUsers, "User", opts)
+	if err != nil {
+		log.Printf("[ERROR] Failed to fetch users: %v", err)
+		return nil, err
+	}
+
+	return objs, nil
+}
+
+func getTeams(api client.Client) ([]map[string]interface{}, error) {
+	opts := &client.GetOptions{}
+	opts.Fields = []string{"id", "name", "modelIndex", "service"}
+	objs, err := api.GetCollection(client.ServiceUsers, "Team", opts)
+	if err != nil {
+		log.Printf("[ERROR] Failed to fetch teams: %v", err)
+		return nil, err
+	}
+
+	return objs, nil
+}

--- a/pkg/nirmata/resource_cluster.go
+++ b/pkg/nirmata/resource_cluster.go
@@ -152,7 +152,7 @@ func resourceClusterCreate(d *schema.ResourceData, meta interface{}) error {
 		"cloudProvider":  spec["cloud"],
 		"systemMetadata": systemMetadata,
 		"overrideValues": fieldsToOverride,
-		"endpoint": 	  endpoint,
+		"endpoint":       endpoint,
 	}
 
 	data["nodePools"] = nodepool

--- a/pkg/nirmata/resource_cluster_registered.go
+++ b/pkg/nirmata/resource_cluster_registered.go
@@ -12,6 +12,35 @@ import (
 	"github.com/nirmata/go-client/pkg/client"
 )
 
+var accessControlSchema = map[string]*schema.Schema{
+	"entity_type": {
+		Type:         schema.TypeString,
+		Required:     true,
+		ValidateFunc: validateEntity,
+	},
+	"permission": {
+		Type:         schema.TypeString,
+		Required:     true,
+		ValidateFunc: validatePermission,
+	},
+	"name": {
+		Type:     schema.TypeString,
+		Required: true,
+	},
+}
+
+var ownerInfoSchema = map[string]*schema.Schema{
+	"owner_type": {
+		Type:         schema.TypeString,
+		Required:     true,
+		ValidateFunc: validateEntity,
+	},
+	"owner_name": {
+		Type:     schema.TypeString,
+		Required: true,
+	},
+}
+
 var registeredClusterSchema = map[string]*schema.Schema{
 	"name": {
 		Type:         schema.TypeString,
@@ -54,6 +83,21 @@ var registeredClusterSchema = map[string]*schema.Schema{
 		Type:     schema.TypeString,
 		Optional: true,
 	},
+	"owner_info": {
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: ownerInfoSchema,
+		},
+	},
+	"access_control_list": {
+		Type:     schema.TypeList,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: accessControlSchema,
+		},
+	},
 }
 
 func resourceClusterRegistered() *schema.Resource {
@@ -72,12 +116,136 @@ func resourceClusterRegistered() *schema.Resource {
 	}
 }
 
+func fetchOwnerId(owner_type, owner_name string, users, teams []map[string]interface{}) (string, error) {
+	var data []map[string]interface{}
+	if owner_type == "user" {
+		data = users
+	} else {
+		data = teams
+	}
+	for _, d := range data {
+		if owner_name == d["name"] {
+			id := d["id"].(string)
+			log.Printf("[DEBUG] - Found match for owner_name %s with id %s", owner_name, id)
+			return id, nil
+		}
+	}
+	return "", fmt.Errorf("[ERROR] - id not found for %s/%s", owner_type, owner_name)
+}
+
+func makeAccessControlListObj(ownerInfo []interface{}, users, teams []map[string]interface{}) (map[string]interface{}, error) {
+	var accessControlListObj map[string]interface{}
+	// Set owner_type to user as the default when no owner_info is provided
+	var owner_type string = "user"
+	var owner_name string
+
+	if ownerInfo != nil && len(ownerInfo) != 0 {
+		for _, o := range ownerInfo {
+			elem, ok := o.(map[string]interface{})
+			if ok {
+				owner_type = elem["owner_type"].(string)
+				owner_name = elem["owner_name"].(string)
+				owner_id, err := fetchOwnerId(owner_type, owner_name, users, teams)
+				if err != nil {
+					log.Printf("[ERROR] - No entity of type %s with name %s found in the cluster", owner_type, owner_name)
+					return nil, fmt.Errorf("[ERROR] - Invalid owner '%s/%s' provided", owner_type, owner_name)
+				}
+				accessControlListObj = map[string]interface{}{
+					"modelIndex": "AccessControlList",
+					"ownerType":  owner_type,
+					"ownerName":  owner_name,
+					"ownerId":    owner_id,
+				}
+			}
+		}
+	} else {
+		log.Printf("[DEBUG] - owner_info is empty")
+		accessControlListObj = map[string]interface{}{
+			"modelIndex": "AccessControlList",
+			"ownerType":  owner_type,
+		}
+	}
+	return accessControlListObj, nil
+}
+
+func makeAccessControlList(accessControlList []interface{}, users, teams []map[string]interface{}) ([]interface{}, error) {
+	var acObArr = make([]interface{}, 0)
+
+	if accessControlList != nil {
+		for _, ac := range accessControlList {
+			log.Printf("[DEBUG] - ac %v", ac)
+			elem, ok := ac.(map[string]interface{})
+			if ok {
+				entity_type := elem["entity_type"].(string)
+				entity_name := elem["name"].(string)
+				entity_id, err := fetchOwnerId(entity_type, entity_name, users, teams)
+				if err != nil {
+					log.Printf("[ERROR] - No entity of type %s with name %s found in the cluster", entity_type, entity_name)
+					return nil, fmt.Errorf("[ERROR] - Invalid entity '%s/%s' provided", entity_type, entity_name)
+				}
+				acOb := map[string]interface{}{
+					"modelIndex": "AccessControl",
+					"entityType": entity_type,
+					"entityName": entity_name,
+					"permission": elem["permission"],
+					"entityId":   entity_id,
+				}
+				log.Printf("[DEBUG] - Printing accessControlList - acOb %v", acOb)
+				acObArr = append(acObArr, acOb)
+			}
+		}
+	}
+	return acObArr, nil
+}
+
 func resourceClusterRegisteredCreate(d *schema.ResourceData, meta interface{}) error {
 	apiClient := meta.(client.Client)
 	name := d.Get("name").(string)
 	labels := d.Get("labels")
 	endpoint := d.Get("endpoint").(string)
 	clusterType := d.Get("cluster_type").(string)
+
+	users, err := getUsers(apiClient)
+	if err != nil {
+		log.Printf("[ERROR] - failed to retrieve users: %v", err)
+		return fmt.Errorf("[ERROR] - Fetching users failed")
+	}
+	log.Println("[DEBUG] - Printing users")
+	for _, u := range users {
+		for k, v := range u {
+			log.Printf("[DEBUG] - key: %s - value: %s", k, v)
+		}
+	}
+
+	teams, err := getTeams(apiClient)
+	if err != nil {
+		log.Printf("[ERROR] - failed to retrieve teams: %v", err)
+		return fmt.Errorf("[ERROR] - Fetching teams failed")
+	}
+	log.Println("[DEBUG] - Printing teams")
+	for _, t := range teams {
+		for k, v := range t {
+			log.Printf("[DEBUG] - key: %s - value: %s", k, v)
+		}
+	}
+
+	ownerInfo := d.Get("owner_info").([]interface{})
+	log.Printf("[DEBUG] - Printing owner_info from resource %v", ownerInfo)
+
+	accessControlListObj, err := makeAccessControlListObj(ownerInfo, users, teams)
+	if err != nil {
+		return err
+	}
+	log.Printf("[DEBUG] - Printing accessControlListObj %v", accessControlListObj)
+
+	accessControlList := d.Get("access_control_list").([]interface{})
+	log.Printf("[DEBUG] - Printing accessControlList %v", accessControlList)
+	acObArr, err := makeAccessControlList(accessControlList, users, teams)
+	if err != nil {
+		return err
+	}
+	accessControlListObj["accessControls"] = acObArr
+	log.Println("[DEBUG] - Printing accessControlList", accessControlListObj)
 
 	deleteAction := d.Get("delete_action").(string)
 	if deleteAction == "" {
@@ -108,11 +276,15 @@ func resourceClusterRegisteredCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	data["config"] = map[string]interface{}{
-		"modelIndex":     "ClusterConfig",
-		"version":        spec["version"],
-		"cloudProvider":  spec["cloud"],
-		"endpoint": 	  endpoint,
+		"modelIndex":    "ClusterConfig",
+		"version":       spec["version"],
+		"cloudProvider": spec["cloud"],
+		"endpoint":      endpoint,
 	}
+
+	var aclArr = make([]interface{}, 0)
+	aclArr = append(aclArr, accessControlListObj)
+	data["accessControlList"] = aclArr
 
 	log.Printf("[DEBUG] - registering cluster %s with %+v", name, data)
 	clusterObj, err := apiClient.PostFromJSON(client.ServiceClusters, "KubernetesCluster", data, nil)

--- a/pkg/nirmata/validate.go
+++ b/pkg/nirmata/validate.go
@@ -78,3 +78,23 @@ func validateDeleteAction(v interface{}, k string) (ws []string, errors []error)
 
 	return
 }
+
+func validatePermission(v interface{}, k string) (ws []string, errors []error) {
+	val := v.(string)
+	if val != "admin" && val != "edit" && val != "view" {
+		errors = append(errors, fmt.Errorf(
+			"%s is not a valid permission; expected 'admin' or 'edit' or 'view'", val))
+	}
+
+	return
+}
+
+func validateEntity(v interface{}, k string) (ws []string, errors []error) {
+	val := v.(string)
+	if val != "user" && val != "team" {
+		errors = append(errors, fmt.Errorf(
+			"%s is not a valid entity; expected 'user' or 'team'", val))
+	}
+
+	return
+}


### PR DESCRIPTION
Added the following optional params for cluster registration:
* owner_info: User can update the owner_info through this
* access_control_list: A list where ACLs for users/teams can be provided

    The provider fetches the users and teams information through an API call.
    It validates the provided user and team information with the information
    fetched from the cluster.
    The provider framework does the other validation of type and permission and
    optional parameters.
    Post a successful validation, the accessControlList object is added to the data
    in the POST request for registering the cluster