### PR TITLE
Allow duplicate cluster names during registration

### DIFF
--- a/examples/register/aks/aks.tf
+++ b/examples/register/aks/aks.tf
@@ -29,8 +29,8 @@ provider "azurerm" {
 }
 
 data "azurerm_kubernetes_cluster" "cluster" {
-  name                = "test"
-  resource_group_name = "test-0_group"
+  name                = "test-tf-import"
+  resource_group_name = "test-tf-import_group"
 }
 
 provider "kubectl" {
@@ -52,13 +52,6 @@ data "kubectl_filename_list" "crd" {
 
 data "kubectl_filename_list" "deployment" {
    pattern = "${nirmata_cluster_registered.aks-registered.controller_yamls_folder}/temp-03-*"
-}
-
-
-// Register Nirmata Cluster
-resource "nirmata_cluster_registered" "aks-registered" {
-  name         = var.nirmata_cluster_name
-  cluster_type = var.nirmata_cluster_type
 }
 
 // apply the controller YAMLs

--- a/examples/register/eks/eks.tf
+++ b/examples/register/eks/eks.tf
@@ -59,13 +59,6 @@ data "kubectl_filename_list" "deployment" {
    pattern = "${nirmata_cluster_registered.eks-registered.controller_yamls_folder}/temp-03-*"
 }
 
-
-// Register Nirmata Cluster
-resource "nirmata_cluster_registered" "eks-registered" {
-  name         = var.nirmata_cluster_name
-  cluster_type = var.nirmata_cluster_type
-}
-
 // apply the controller YAMLs
 resource "kubectl_manifest" "namespace" {
   wait        = true

--- a/examples/register/gke/gke.tf
+++ b/examples/register/gke/gke.tf
@@ -44,13 +44,6 @@ data "kubectl_filename_list" "deployment" {
    pattern = "${nirmata_cluster_registered.gke-registered.controller_yamls_folder}/temp-03-*"
 }
 
-
-// Register Nirmata Cluster
-resource "nirmata_cluster_registered" "gke-registered" {
-  name         = var.nirmata_cluster_name
-  cluster_type = var.nirmata_cluster_type
-}
-
 // apply the controller YAMLs
 resource "kubectl_manifest" "namespace" {
   wait        = true

--- a/examples/register/kind/kind.tf
+++ b/examples/register/kind/kind.tf
@@ -46,13 +46,6 @@ data "kubectl_filename_list" "deployment" {
    pattern = "${nirmata_cluster_registered.kind-registered.controller_yamls_folder}/temp-03-*"
 }
 
-
-// Register Nirmata Cluster
-resource "nirmata_cluster_registered" "kind-registered" {
-  name         = var.nirmata_cluster_name
-  cluster_type = var.nirmata_cluster_type
-}
-
 // apply the controller YAMLs
 resource "kubectl_manifest" "namespace" {
   wait        = true

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
-	github.com/nirmata/go-client v1.0.6
+	github.com/nirmata/go-client v1.0.7
 	github.com/stretchr/testify v1.6.1 // indirect
 	golang.org/x/sys v0.1.0 // indirect
 	golang.org/x/text v0.3.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/mitchellh/reflectwalk v1.0.1 h1:FVzMWA5RllMAKIdUSC8mdWo3XtwoecrH79BY7
 github.com/mitchellh/reflectwalk v1.0.1/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nirmata/go-client v1.0.6 h1:fZ7PcHy3eLBkFxk8WpB8zxVog8m1mEbGOsadO3atiPQ=
-github.com/nirmata/go-client v1.0.6/go.mod h1:jUmiMEmk8PbxpJETAyB5L7PMz81u0RxHPj8/OO7rgnc=
+github.com/nirmata/go-client v1.0.7 h1:fLrgsN5XCOpKtAA8hce514VWGON1bTj/fhCRZf4B46Y=
+github.com/nirmata/go-client v1.0.7/go.mod h1:jUmiMEmk8PbxpJETAyB5L7PMz81u0RxHPj8/OO7rgnc=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=

--- a/pkg/nirmata/resource_cluster_registered.go
+++ b/pkg/nirmata/resource_cluster_registered.go
@@ -364,7 +364,7 @@ func resourceClusterRegisteredCreate(d *schema.ResourceData, meta interface{}) e
 	clusterUUID := clusterObj["id"].(string)
 	d.SetId(clusterUUID)
 
-	clusterData, err := apiClient.QueryByName(client.ServiceClusters, "KubernetesCluster", name)
+	clusterData, err := apiClient.QueryById(client.ServiceClusters, "KubernetesCluster", clusterUUID)
 	if err != nil {
 		log.Printf("[ERROR] - %v", err)
 		return err


### PR DESCRIPTION
Used a newer version of go-client with QueryById method to query KubernetesCluster by Id.
Fixed some minor issues with example terraform files.